### PR TITLE
Added in embedded job board to allow people through A2RB to post jobs

### DIFF
--- a/_sass/_a2rb.scss
+++ b/_sass/_a2rb.scss
@@ -145,6 +145,11 @@ input {
   }
 }
 
+.disclaimer {
+  font-size: 0.8em;
+  text-align: center;
+}
+
 .splash-container {
   background: url('/img/a2rb-splash-bg.jpg') no-repeat;
   background-size: cover;

--- a/jobs.md
+++ b/jobs.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: Jobs
+long_title: Job Postings on A2RB
+permalink: /jobs/
+---
+
+<script async src="https://www.truejob.com/widget.js?portal=a2rb"></script>
+

--- a/jobs.md
+++ b/jobs.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Jobs
-long_title: Job Postings on A2RB
+long_title: Local Job Openings
 permalink: /jobs/
 ---
 

--- a/jobs.md
+++ b/jobs.md
@@ -7,3 +7,8 @@ permalink: /jobs/
 
 <script async src="https://www.truejob.com/widget.js?portal=a2rb"></script>
 
+<p class="disclaimer">
+  <em>
+    Job listings posted here or on TrueJob are not necessarily endorsed by the a2rb organization, or any organizers of a2rb. If you have questions, comments, or concerns regarding this job board or a job posting posted here, please contact <a href="mailto:support@truejob.com?subject=[a2rb Job Board] Support Request" target="_blank">support@truejob.com</a> or reach out to an organizer.
+  </em>
+</p>

--- a/jobs.md
+++ b/jobs.md
@@ -5,10 +5,10 @@ long_title: Job Postings on A2RB
 permalink: /jobs/
 ---
 
-<script async src="https://www.truejob.com/widget.js?portal=a2rb"></script>
-
 <p class="disclaimer">
   <em>
-    Job listings posted here or on TrueJob are not necessarily endorsed by the a2rb organization, or any organizers of a2rb. If you have questions, comments, or concerns regarding this job board or a job posting posted here, please contact <a href="mailto:support@truejob.com?subject=[a2rb Job Board] Support Request" target="_blank">support@truejob.com</a> or reach out to an organizer.
+    Job listings posted here or on TrueJob are not necessarily endorsed by the a2rb organization, or any organizers of a2rb. Questions? please contact <a href="mailto:support@truejob.com?subject=[a2rb Job Board] Support Request" target="_blank">support@truejob.com</a>.
   </em>
 </p>
+
+<script async src="https://www.truejob.com/widget.js?portal=a2rb"></script>


### PR DESCRIPTION
Hey guys,

I've noticed at the past few a2rbs I've gone to that more and more people have started mentioning they were looking to hire, or people wanted to be hired. 

As a member of a2rb, and also someone who built a job site with ruby on rails, I built an embedded job portal for a2rb to allow people to post and list jobs free right on the website. No employer would be allowed to post that wasn't approved, and we can customize this more to fit the site more if you guys want. Let me know what you think! Here's how it looks:

**The site, now with the job page at the top:**
<img width="1920" alt="screen shot 2016-04-07 at 10 54 34 am" src="https://cloud.githubusercontent.com/assets/463175/14356122/95e0d898-fcb1-11e5-9f40-dfc0f1eff83b.png">

**The job board page with no jobs on it:**
<img width="1920" alt="screen shot 2016-04-07 at 11 14 11 am" src="https://cloud.githubusercontent.com/assets/463175/14356199/e4825486-fcb1-11e5-9146-71942dc8a6ea.png">

**What happens when you click "Employer sign up":**
<img width="1920" alt="screen shot 2016-04-07 at 10 56 02 am" src="https://cloud.githubusercontent.com/assets/463175/14356208/eef87a8a-fcb1-11e5-9621-1f3313961fa9.png">

**Posting a new job posting:**
<img width="1919" alt="screen shot 2016-04-07 at 11 04 53 am" src="https://cloud.githubusercontent.com/assets/463175/14356227/fadb9d46-fcb1-11e5-883e-5b116fdaa614.png">

**What the embedded job page looks like after you post a job**
<img width="1920" alt="screen shot 2016-04-07 at 11 05 36 am" src="https://cloud.githubusercontent.com/assets/463175/14356137/a574a780-fcb1-11e5-92c3-8c4fdc3c8371.png">

Let me know what you guys think!
